### PR TITLE
require_tree argument must be a directory

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,13 +22,7 @@
 //= require angular-highlightjs/angular-highlightjs
 //= require nprogress
 
-//= require ldpath-app/app
-//= require_tree ./ldpath-app/templates
 //= require_tree ./ldpath-app/modules
-//= require_tree ./ldpath-app/filters
-//= require_tree ./ldpath-app/directives
-//= require_tree ./ldpath-app/models
-//= require_tree ./ldpath-app/services
 //= require_tree ./ldpath-app/controllers
 
 //= require_tree .


### PR DESCRIPTION
Trying to get this to work for me. Changed
app/assets/javascripts/application.js to remove require_tree statements for directories that didn’t exist. The issue I was having seemed similar to https://github.com/cbeer/ldpath-angular-demo-app/issues/1 and this change fixed it for me.
